### PR TITLE
Create jsonobject.sh

### DIFF
--- a/jsonobject.sh
+++ b/jsonobject.sh
@@ -1,0 +1,5 @@
+# AWS CLI command to assume an IAM role using STS
+aws sts assume-role \
+    --role-arn arn:aws:iam::typeyouriamidhere:role/typeyouriamrolehere \ # Replace with your actual role ARN
+    --role-session-name $(echo $RANDOM | base64 | head -c 20; echo) \ # Generate a random session name
+    --profile cloud_user # Specify an AWS CLI profile


### PR DESCRIPTION
Shell command that uses the AWS CLI to assume an IAM role using the Security Token Service (STS). It also generates a random session name and specifies a named AWS CLI profile.